### PR TITLE
Install latest Helm version

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -11,7 +11,9 @@ echo ""
 
 mkdir -p /opt/download
 cd /opt/download
-HELM_VERSION=3.9.0
+
+LATEST_RELEASE=$(curl https://api.github.com/repos/helm/helm/releases/latest | jq --raw-output '.tag_name' | cut -c 2-)
+HELM_VERSION=${LATEST_RELEASE}
 
 function install_helm() {
     if [[ "$HELM_VERSION" == '3.2.0' ]]; then
@@ -31,4 +33,3 @@ function install_helm_s3() {
 
 install_helm
 install_helm_s3
-

--- a/install.sh
+++ b/install.sh
@@ -33,3 +33,6 @@ function install_helm_s3() {
 
 install_helm
 install_helm_s3
+
+# Verify Helm installation
+helm version


### PR DESCRIPTION
Part of the https://github.com/bitovi/bitops/issues/307

Previously, the Helm version was pinned in the plugin installation script.
With this PR when packaging the Helm plugin in the custom-built BitOps image, the latest version will be downloaded by default.
